### PR TITLE
[bugfix] JENKINS-22102 typo in config.jelly 

### DIFF
--- a/src/main/resources/jenkins/plugins/nodejs/NodeJsCommandInterpreter/config.jelly
+++ b/src/main/resources/jenkins/plugins/nodejs/NodeJsCommandInterpreter/config.jelly
@@ -2,7 +2,7 @@
     <f:entry title="${%NodeJS Installation}" field="nodejs_installationName">
         <select class="setting-input" name="nodejs_installationName">
             <j:forEach var="inst" items="${descriptor.installations}">
-                <f:option selected="${inst.name==it.nodeJSInstallationName}">${inst.name}</f:option>
+                <f:option selected="${inst.name==instance.nodeJSInstallationName}">${inst.name}</f:option>
             </j:forEach>
         </select>
     </f:entry>


### PR DESCRIPTION
instance should be used instead of it in selected option in nodeJSInstallationName
