### PR TITLE
[FIX JENKINS-33698] NodeJS plugin npm install without root permissions

### DIFF
--- a/src/main/java/jenkins/plugins/nodejs/tools/NodeJSInstaller.java
+++ b/src/main/java/jenkins/plugins/nodejs/tools/NodeJSInstaller.java
@@ -32,16 +32,14 @@ import hudson.Functions;
 import hudson.Util;
 import hudson.model.Node;
 import hudson.model.TaskListener;
-import hudson.os.PosixAPI;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.plugins.tools.Installables;
 import hudson.remoting.VirtualChannel;
 import hudson.tools.DownloadFromUrlInstaller;
 import hudson.tools.ToolInstallation;
 import hudson.util.ArgumentListBuilder;
-import hudson.util.jna.GNUCLibrary;
-
 import jenkins.security.MasterToSlaveCallable;
+
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -52,7 +50,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 
 import static jenkins.plugins.nodejs.tools.NodeJSInstaller.Preference.*;
 
@@ -243,17 +240,7 @@ public class NodeJSInstaller extends DownloadFromUrlInstaller {
         @IgnoreJRERequirement
         private void process(File f) {
             if (f.isFile()) {
-                if(Functions.isMustangOrAbove())
-                    f.setExecutable(true, false);
-                else {
-                    try {
-                        GNUCLibrary.LIBC.chmod(f.getAbsolutePath(),0755);
-                    } catch (LinkageError e) {
-                        // if JNA is unavailable, fall back.
-                        // we still prefer to try JNA first as PosixAPI supports even smaller platforms.
-                        PosixAPI.get().chmod(f.getAbsolutePath(),0755);
-                    }
-                }
+                f.setExecutable(true, false);
             } else {
                 File[] kids = f.listFiles();
                 if (kids != null) {
@@ -375,6 +362,7 @@ public class NodeJSInstaller extends DownloadFromUrlInstaller {
     /**
      * Indicates the failure to detect the OS or CPU.
      */
+    @SuppressWarnings("serial")
     private static final class DetectionFailedException extends Exception {
         private DetectionFailedException(String message) {
             super(message);
@@ -417,5 +405,4 @@ public class NodeJSInstaller extends DownloadFromUrlInstaller {
         }
     }
 
-    private static final Logger LOGGER = Logger.getLogger(NodeJSInstaller.class.getName());
 }

--- a/src/main/java/jenkins/plugins/nodejs/tools/NpmConfig.java
+++ b/src/main/java/jenkins/plugins/nodejs/tools/NpmConfig.java
@@ -1,0 +1,141 @@
+package jenkins.plugins.nodejs.tools;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.commons.io.IOUtils;
+
+/**
+ * Npm config file parser.
+ * 
+ * @author Nikolas Falco
+ *
+ */
+public class NpmConfig {
+
+    private static final String UTF_8 = "UTF-8";
+
+    private File file;
+    private Map<Object, String> properties;
+
+    public static NpmConfig load(File file) throws IOException {
+        NpmConfig npmConfig = new NpmConfig(file);
+        npmConfig.load();
+        return npmConfig;
+    }
+
+    public NpmConfig(File file) {
+        if (file == null) {
+            throw new NullPointerException("file is null");
+        }
+        if (!file.isFile()) {
+            throw new IllegalArgumentException("file " + file + " does not exists");
+        }
+
+        this.file = file;
+        this.properties = new LinkedHashMap<Object, String>();
+    }
+
+    public void load() throws IOException {
+        properties.clear();
+
+        FileInputStream fis = null;
+        try {
+            fis = new FileInputStream(file);
+            for (String line : IOUtils.readLines(fis, UTF_8)) {
+                line = line.trim();
+                if (line.length() == 0) {
+                    continue;
+                }
+                if (line.startsWith(";")) {
+                    // comment
+                    addComment(line.substring(1));
+                } else {
+                    int eqIndex = line.indexOf('=');
+                    if (eqIndex != -1) { // NOSONAR
+                        String key = line.substring(0, eqIndex).trim();
+                        String value = line.substring(eqIndex + 1).trim();
+                        properties.put(key, value);
+                    } else {
+                        // parse error
+                        addComment(line);
+                    }
+                }
+            }
+        } finally {
+            IOUtils.closeQuietly(fis);
+        }
+    }
+
+    /**
+     * Add a comment line at the end of the file.
+     * 
+     * @param comment the text content without the ';' suffix
+     */
+    public void addComment(String comment) {
+        properties.put(new Comment() {}, comment);
+    }
+
+    public void save() throws IOException {
+        FileOutputStream writer = null;
+        try {
+            writer = new FileOutputStream(file);
+            for (Entry<Object, String> entry : properties.entrySet()) {
+                String line;
+                if (entry.getKey() instanceof Comment) {
+                    line = ';' + entry.getValue();
+                } else {
+                    line = entry.getKey() + " = " + entry.getValue();
+                }
+                IOUtils.writeLines(Arrays.asList(line), null, writer, UTF_8);
+            }
+        } finally {
+            IOUtils.closeQuietly(writer);
+        }
+    }
+
+    public boolean containsKey(String key) {
+        return properties.containsKey(key);
+    }
+
+    /**
+     * Get the value for the specified property key.
+     * 
+     * @param key
+     * @return the property value
+     */
+    public String get(String key) {
+        return properties.get(key);
+    }
+
+    /**
+     * Set the value for the specified property key. If key already present it
+     * will be override.
+     * 
+     * @param key property key
+     * @param value property value
+     * @return the old value associated to the property key, <code>null</code>
+     *         otherwise
+     */
+    public String set(String key, String value) {
+        return properties.put(key, value);
+    }
+
+    /**
+     * Marker interface.
+     * <p>
+     * This class is intended to avoid collision if a special entry key was
+     * choose to represent comment in the map.
+     * 
+     * @author Nikolas Falco
+     *
+     */
+    private interface Comment {
+    }
+}

--- a/src/main/java/jenkins/plugins/nodejs/tools/Version.java
+++ b/src/main/java/jenkins/plugins/nodejs/tools/Version.java
@@ -1,0 +1,427 @@
+/*
+ * Copyright (c) OSGi Alliance (2004, 2014). All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jenkins.plugins.nodejs.tools;
+
+import java.util.NoSuchElementException;
+import java.util.StringTokenizer;
+
+/**
+ * Version identifier for capabilities such as bundles and packages.
+ * 
+ * <p>
+ * Version identifiers have four components.
+ * <ol>
+ * <li>Major version. A non-negative integer.</li>
+ * <li>Minor version. A non-negative integer.</li>
+ * <li>Micro version. A non-negative integer.</li>
+ * <li>Qualifier. A text string. See {@code Version(String)} for the format of
+ * the qualifier string.</li>
+ * </ol>
+ * 
+ * <p>
+ * {@code Version} objects are immutable.
+ * 
+ * @since 1.3
+ * @Immutable
+ * @author $Id: c24d4d37a0657ac69de29085d2d290cbb0031c4a $
+ */
+
+public class Version implements Comparable<Version> {
+	private final int			major;
+	private final int			minor;
+	private final int			micro;
+	private final String		qualifier;
+	private static final String	SEPARATOR		= ".";
+	private transient String	versionString /* default to null */;
+	private transient int		hash /* default to 0 */;
+
+	/**
+	 * The empty version "0.0.0".
+	 */
+	public static final Version	emptyVersion	= new Version(0, 0, 0);
+
+	/**
+	 * Creates a version identifier from the specified numerical components.
+	 * 
+	 * <p>
+	 * The qualifier is set to the empty string.
+	 * 
+	 * @param major Major component of the version identifier.
+	 * @param minor Minor component of the version identifier.
+	 * @param micro Micro component of the version identifier.
+	 * @throws IllegalArgumentException If the numerical components are
+	 *         negative.
+	 */
+	public Version(int major, int minor, int micro) {
+		this(major, minor, micro, null);
+	}
+
+	/**
+	 * Creates a version identifier from the specified components.
+	 * 
+	 * @param major Major component of the version identifier.
+	 * @param minor Minor component of the version identifier.
+	 * @param micro Micro component of the version identifier.
+	 * @param qualifier Qualifier component of the version identifier. If
+	 *        {@code null} is specified, then the qualifier will be set to the
+	 *        empty string.
+	 * @throws IllegalArgumentException If the numerical components are negative
+	 *         or the qualifier string is invalid.
+	 */
+	public Version(int major, int minor, int micro, String qualifier) {
+		if (qualifier == null) {
+			qualifier = "";
+		}
+
+		this.major = major;
+		this.minor = minor;
+		this.micro = micro;
+		this.qualifier = qualifier;
+		validate();
+	}
+
+	/**
+	 * Creates a version identifier from the specified string.
+	 * 
+	 * <p>
+	 * Version string grammar:
+	 * 
+	 * <pre>
+	 * version ::= major('.'minor('.'micro('.'qualifier)?)?)?
+	 * major ::= digit+
+	 * minor ::= digit+
+	 * micro ::= digit+
+	 * qualifier ::= (alpha|digit|'_'|'-')+
+	 * digit ::= [0..9]
+	 * alpha ::= [a..zA..Z]
+	 * </pre>
+	 * 
+	 * @param version String representation of the version identifier. There
+	 *        must be no whitespace in the argument.
+	 * @throws IllegalArgumentException If {@code version} is improperly
+	 *         formatted.
+	 */
+	public Version(String version) {
+		int maj = 0;
+		int min = 0;
+		int mic = 0;
+		String qual = "";
+
+		try {
+			StringTokenizer st = new StringTokenizer(version, SEPARATOR, true);
+			maj = parseInt(st.nextToken(), version);
+
+			if (st.hasMoreTokens()) { // minor
+				st.nextToken(); // consume delimiter
+				min = parseInt(st.nextToken(), version);
+
+				if (st.hasMoreTokens()) { // micro
+					st.nextToken(); // consume delimiter
+					mic = parseInt(st.nextToken(), version);
+
+					if (st.hasMoreTokens()) { // qualifier separator
+						st.nextToken(); // consume delimiter
+						qual = st.nextToken(""); // remaining string
+
+						if (st.hasMoreTokens()) { // fail safe
+							throw new IllegalArgumentException("invalid version \"" + version + "\": invalid format");
+						}
+					}
+				}
+			}
+		} catch (NoSuchElementException e) {
+			IllegalArgumentException iae = new IllegalArgumentException("invalid version \"" + version + "\": invalid format");
+			iae.initCause(e);
+			throw iae;
+		}
+
+		major = maj;
+		minor = min;
+		micro = mic;
+		qualifier = qual;
+		validate();
+	}
+
+	/**
+	 * Parse numeric component into an int.
+	 * 
+	 * @param value Numeric component
+	 * @param version Complete version string for exception message, if any
+	 * @return int value of numeric component
+	 */
+	private static int parseInt(String value, String version) {
+		try {
+			return Integer.parseInt(value);
+		} catch (NumberFormatException e) {
+			IllegalArgumentException iae = new IllegalArgumentException("invalid version \"" + version + "\": non-numeric \"" + value + "\"");
+			iae.initCause(e);
+			throw iae;
+		}
+	}
+
+	/**
+	 * Called by the Version constructors to validate the version components.
+	 * 
+	 * @throws IllegalArgumentException If the numerical components are negative
+	 *         or the qualifier string is invalid.
+	 */
+	private void validate() {
+		if (major < 0) {
+			throw new IllegalArgumentException("invalid version \"" + toString0() + "\": negative number \"" + major + "\"");
+		}
+		if (minor < 0) {
+			throw new IllegalArgumentException("invalid version \"" + toString0() + "\": negative number \"" + minor + "\"");
+		}
+		if (micro < 0) {
+			throw new IllegalArgumentException("invalid version \"" + toString0() + "\": negative number \"" + micro + "\"");
+		}
+		for (char ch : qualifier.toCharArray()) {
+			if (('A' <= ch) && (ch <= 'Z')) {
+				continue;
+			}
+			if (('a' <= ch) && (ch <= 'z')) {
+				continue;
+			}
+			if (('0' <= ch) && (ch <= '9')) {
+				continue;
+			}
+			if ((ch == '_') || (ch == '-')) {
+				continue;
+			}
+			throw new IllegalArgumentException("invalid version \"" + toString0() + "\": invalid qualifier \"" + qualifier + "\"");
+		}
+	}
+
+	/**
+	 * Parses a version identifier from the specified string.
+	 * 
+	 * <p>
+	 * See {@link #Version(String)} for the format of the version string.
+	 * 
+	 * @param version String representation of the version identifier. Leading
+	 *        and trailing whitespace will be ignored.
+	 * @return A {@code Version} object representing the version identifier. If
+	 *         {@code version} is {@code null} or the empty string then
+	 *         {@link #emptyVersion} will be returned.
+	 * @throws IllegalArgumentException If {@code version} is improperly
+	 *         formatted.
+	 */
+	public static Version parseVersion(String version) {
+		if (version == null) {
+			return emptyVersion;
+		}
+
+		return valueOf(version);
+	}
+
+	/**
+	 * Returns a {@code Version} object holding the version identifier in the
+	 * specified {@code String}.
+	 * 
+	 * <p>
+	 * See {@link #Version(String)} for the format of the version string.
+	 * 
+	 * <p>
+	 * This method performs a similar function as {@link #parseVersion(String)}
+	 * but has the static factory {@code valueOf(String)} method signature.
+	 * 
+	 * @param version String representation of the version identifier. Leading
+	 *        and trailing whitespace will be ignored. Must not be {@code null}.
+	 * @return A {@code Version} object representing the version identifier. If
+	 *         {@code version} is the empty string then {@link #emptyVersion}
+	 *         will be returned.
+	 * @throws IllegalArgumentException If {@code version} is improperly
+	 *         formatted.
+	 * @since 1.8
+	 */
+	public static Version valueOf(String version) {
+		version = version.trim();
+		if (version.length() == 0) {
+			return emptyVersion;
+		}
+
+		return new Version(version);
+	}
+
+	/**
+	 * Returns the major component of this version identifier.
+	 * 
+	 * @return The major component.
+	 */
+	public int getMajor() {
+		return major;
+	}
+
+	/**
+	 * Returns the minor component of this version identifier.
+	 * 
+	 * @return The minor component.
+	 */
+	public int getMinor() {
+		return minor;
+	}
+
+	/**
+	 * Returns the micro component of this version identifier.
+	 * 
+	 * @return The micro component.
+	 */
+	public int getMicro() {
+		return micro;
+	}
+
+	/**
+	 * Returns the qualifier component of this version identifier.
+	 * 
+	 * @return The qualifier component.
+	 */
+	public String getQualifier() {
+		return qualifier;
+	}
+
+	/**
+	 * Returns the string representation of this version identifier.
+	 * 
+	 * <p>
+	 * The format of the version string will be {@code major.minor.micro} if
+	 * qualifier is the empty string or {@code major.minor.micro.qualifier}
+	 * otherwise.
+	 * 
+	 * @return The string representation of this version identifier.
+	 */
+	@Override
+	public String toString() {
+		return toString0();
+	}
+
+	/**
+	 * Internal toString behavior
+	 * 
+	 * @return The string representation of this version identifier.
+	 */
+	String toString0() {
+		String s = versionString;
+		if (s != null) {
+			return s;
+		}
+		int q = qualifier.length();
+		StringBuffer result = new StringBuffer(20 + q);
+		result.append(major);
+		result.append(SEPARATOR);
+		result.append(minor);
+		result.append(SEPARATOR);
+		result.append(micro);
+		if (q > 0) {
+			result.append(SEPARATOR);
+			result.append(qualifier);
+		}
+		return versionString = result.toString();
+	}
+
+	/**
+	 * Returns a hash code value for the object.
+	 * 
+	 * @return An integer which is a hash code value for this object.
+	 */
+	@Override
+	public int hashCode() {
+		int h = hash;
+		if (h != 0) {
+			return h;
+		}
+		h = 31 * 17;
+		h = 31 * h + major;
+		h = 31 * h + minor;
+		h = 31 * h + micro;
+		h = 31 * h + qualifier.hashCode();
+		return hash = h;
+	}
+
+	/**
+	 * Compares this {@code Version} object to another object.
+	 * 
+	 * <p>
+	 * A version is considered to be <b>equal to </b> another version if the
+	 * major, minor and micro components are equal and the qualifier component
+	 * is equal (using {@code String.equals}).
+	 * 
+	 * @param object The {@code Version} object to be compared.
+	 * @return {@code true} if {@code object} is a {@code Version} and is equal
+	 *         to this object; {@code false} otherwise.
+	 */
+	@Override
+	public boolean equals(Object object) {
+		if (object == this) { // quicktest
+			return true;
+		}
+
+		if (!(object instanceof Version)) {
+			return false;
+		}
+
+		Version other = (Version) object;
+		return (major == other.major) && (minor == other.minor) && (micro == other.micro) && qualifier.equals(other.qualifier);
+	}
+
+	/**
+	 * Compares this {@code Version} object to another {@code Version}.
+	 * 
+	 * <p>
+	 * A version is considered to be <b>less than</b> another version if its
+	 * major component is less than the other version's major component, or the
+	 * major components are equal and its minor component is less than the other
+	 * version's minor component, or the major and minor components are equal
+	 * and its micro component is less than the other version's micro component,
+	 * or the major, minor and micro components are equal and it's qualifier
+	 * component is less than the other version's qualifier component (using
+	 * {@code String.compareTo}).
+	 * 
+	 * <p>
+	 * A version is considered to be <b>equal to</b> another version if the
+	 * major, minor and micro components are equal and the qualifier component
+	 * is equal (using {@code String.compareTo}).
+	 * 
+	 * @param other The {@code Version} object to be compared.
+	 * @return A negative integer, zero, or a positive integer if this version
+	 *         is less than, equal to, or greater than the specified
+	 *         {@code Version} object.
+	 * @throws ClassCastException If the specified object is not a
+	 *         {@code Version} object.
+	 */
+	public int compareTo(Version other) {
+		if (other == this) { // quicktest
+			return 0;
+		}
+
+		int result = major - other.major;
+		if (result != 0) {
+			return result;
+		}
+
+		result = minor - other.minor;
+		if (result != 0) {
+			return result;
+		}
+
+		result = micro - other.micro;
+		if (result != 0) {
+			return result;
+		}
+
+		return qualifier.compareTo(other.qualifier);
+	}
+}

--- a/src/test/java/jenkins/plugins/nodejs/tools/NpmConfigTest.java
+++ b/src/test/java/jenkins/plugins/nodejs/tools/NpmConfigTest.java
@@ -1,0 +1,82 @@
+package jenkins.plugins.nodejs.tools;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class NpmConfigTest {
+
+    private File file;
+
+    @Before
+    public void setUp() throws IOException {
+        InputStream is = null;
+        try {
+            is = getClass().getResourceAsStream("npmrc.config");
+            file = File.createTempFile("npmrc", ".tmp");
+            hudson.util.IOUtils.copy(is, file);
+        } finally {
+            IOUtils.closeQuietly(is);
+        }
+    }
+
+    @After
+    public void tearDown() {
+        if (!file.delete()) {
+            file.deleteOnExit();
+        }
+    }
+
+    @Test
+    public void testLoad() throws Exception {
+        NpmConfig npmrc = NpmConfig.load(file);
+        assertTrue(npmrc.containsKey("always-auth"));
+        assertEquals("true", npmrc.get("always-auth"));
+        assertEquals("\"/var/lib/jenkins/tools/jenkins.plugins.nodejs.tools.NodeJSInstallation/Node_6.x\"", npmrc.get("prefix"));
+    }
+
+    @Test
+    public void testAvoidParseError() throws Exception {
+        NpmConfig npmrc = NpmConfig.load(file);
+        assertFalse(npmrc.containsKey("browser"));
+    }
+
+    @Test
+    public void testSave() throws Exception {
+        String testKey = "test";
+        String testValue = "value";
+
+        NpmConfig npmrc = NpmConfig.load(file);
+        npmrc.set(testKey, testValue);
+        npmrc.save();
+
+        // reload content
+        npmrc = NpmConfig.load(file);
+        assertTrue(npmrc.containsKey(testKey));
+        assertEquals(testValue, npmrc.get(testKey));
+    }
+
+    @Test
+    public void testCommandAtLast() throws Exception {
+        String comment = "test comment";
+
+        NpmConfig npmrc = NpmConfig.load(file);
+        npmrc.addComment(comment);
+        npmrc.save();
+
+        List<String> lines = IOUtils.readLines(new FileInputStream(file), "UTF-8");
+        assertEquals(';' + comment, lines.get(lines.size() - 1));
+    }
+
+}

--- a/src/test/resources/jenkins/plugins/nodejs/tools/npmrc.config
+++ b/src/test/resources/jenkins/plugins/nodejs/tools/npmrc.config
@@ -1,0 +1,26 @@
+; cli configs
+global = true
+long = true
+user-agent = "npm/3.10.3 node/v0.10.42 linux x64"
+
+; userconfig /var/lib/jenkins/.npmrc
+always-auth = true
+
+; builtin config undefined
+prefix="/var/lib"
+
+; globalconfig /var/lib/jenkins/tools/jenkins.plugins.nodejs.tools.NodeJSInstallation/Node_6.x/etc/npmrc
+prefix = "/var/lib/jenkins/tools/jenkins.plugins.nodejs.tools.NodeJSInstallation/Node_6.x"
+
+; default values
+access = null
+also = null
+; always-auth = false (overridden)
+bin-links = true
+ca = null
+cache = "/var/lib/jenkins/.npm"
+cache-lock-retries = 10
+cache-lock-stale = 60000
+
+; parse error test
+browser


### PR DESCRIPTION
For NodeJS >= 6.x version the "prefix" variable is relocated to local
installation tools folder as previous version. This settings could be
override using the npmrc file hierarchy. If a prefix variable is already
present in the default settings of local installation is kept.
