### PR TITLE
[FIXED JENKINS-40624] add @Symbol(“nodejs”) and populate environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.classpath
 /work
 *.iml
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci</groupId>
+            <artifactId>symbol-annotation</artifactId>
+            <version>1.5</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/jenkins/plugins/nodejs/tools/NodeJSInstallation.java
+++ b/src/main/java/jenkins/plugins/nodejs/tools/NodeJSInstallation.java
@@ -13,6 +13,7 @@ import hudson.tools.ToolDescriptor;
 import hudson.tools.ToolInstallation;
 import hudson.tools.ToolProperty;
 import jenkins.security.MasterToSlaveCallable;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
@@ -62,6 +63,15 @@ public class NodeJSInstallation extends ToolInstallation
         return super.getHome();
     }
 
+    @Override
+    public void buildEnvVars(EnvVars env) {
+        String home = getHome();
+        if (home == null) {
+            return;
+        }
+        env.put("PATH+NODEJS", home + "/bin");
+    }
+
     /*
      * (non-Javadoc)
      * @see hudson.tools.ToolInstallation#translate(hudson.model.Node, hudson.EnvVars, hudson.model.TaskListener)
@@ -103,6 +113,7 @@ public class NodeJSInstallation extends ToolInstallation
     }
 
 
+    @Symbol("nodejs")
     @Extension
     public static class DescriptorImpl extends ToolDescriptor<NodeJSInstallation> {
 


### PR DESCRIPTION
this will allow a pipeline definition like this:

```
pipeline {

  tools {
    nodejs "NodeJS_0.10.33"
  }

  agent any
  stages {
    stage ('test') {
      steps {
          sh "node --version"
          sh "npm --version"
      }
    }
  }
}
```

I would have added tests to ensure the symbol works together with the pipeline-model-definition, but then I would need to update core dependency to `2.7.1` - as I don't know if its possible to have tests executed with a different core version for single tests.

cc @abayer @nfalco79 

@nfalco79 according to https://wiki.jenkins-ci.org/display/JENKINS/NodeJS+Plugin this plugin seems open for adoption, would you like to take it over?