### PR TITLE
Fix node PATH while installing npm

### DIFF
--- a/src/main/java/jenkins/plugins/nodejs/tools/NpmPackagesBuildWrapper.java
+++ b/src/main/java/jenkins/plugins/nodejs/tools/NpmPackagesBuildWrapper.java
@@ -80,10 +80,9 @@ public class NpmPackagesBuildWrapper extends BuildWrapper {
 
                 // HACK: Avoids issue with invalid separators in EnvVars::override in case of different master/slave
                 
-                String overriddenPaths = NodeJSInstaller.binFolderOf(nodeJSInstallation, build.getBuiltOn())
-                        + pathSeparator
-                        + vars.get("PATH");
-                vars.override("PATH", overriddenPaths);
+                String nodeJSPath = 
+                    NodeJSInstaller.binFolderOf(nodeJSInstallation, build.getBuiltOn()).getRemote();
+                vars.put("PATH+NODEJS", nodeJSPath);
 
                 return super.launch(starter.envs(Util.mapToEnv(vars)));
             }


### PR DESCRIPTION
The jenkins job which depends on `NodeJS Plugin` and below other plugins, cannot finish successfully.(please see *1 error log)
* other plugins
  * https://wiki.jenkins-ci.org/display/JENKINS/pyenv+plugin
  * https://wiki.jenkins-ci.org/display/JENKINS/rbenv+plugin

Because, `NodeJS Plugin` override the `PATH`, so `pyenv plugin` cannot find the git command on `PATH` for installing pyenv.
* https://github.com/jenkinsci/nodejs-plugin/blob/19f5acc88fb1907adcfdf86e9d81ef901d3b8d62/src/main/java/jenkins/plugins/nodejs/tools/NpmPackagesBuildWrapper.java#L83-L86
* 
  ```
                String overriddenPaths = NodeJSInstaller.binFolderOf(nodeJSInstallation, build.getBuiltOn())
                        + pathSeparator
                        + vars.get("PATH");
                vars.override("PATH", overriddenPaths);
   ```


Instead of overriding `PATH`, this pr adds `"PATH+NODEJS"` to env like  https://github.com/jenkinsci/nodejs-plugin/commit/9a44fe8e046e6aaf85f5abcd45e006780c460dd5

### Jenkins Info
* Jenkins ver. 2.19.4
  * CentOS7
* NodeJS Plugin 0.2.2
* pyenv plugin 0.0.7
* rbenv plugin 0.0.16

### *1 error log 
* jenkins configuration 
* jenkins job log
```
Started by user 
[EnvInject] - Loading node environment variables.
Building remotely on slave-server in workspace /home/jenkins/jenkins_home/workspace/test_job
$ /home/jenkins/jenkins_home/tools/jenkins.plugins.nodejs.tools.NodeJSInstallation/6.9.4LTS/bin/npm install -g bower@~1.7.9 grunt-cli@~0.1.13 gulp@~3.9.1
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated graceful-fs@1.2.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
/home/jenkins/jenkins_home/tools/jenkins.plugins.nodejs.tools.NodeJSInstallation/6.9.4LTS/bin/bower -> /home/jenkins/jenkins_home/tools/jenkins.plugins.nodejs.tools.NodeJSInstallation/6.9.4LTS/lib/node_modules/bower/bin/bower
/home/jenkins/jenkins_home/tools/jenkins.plugins.nodejs.tools.NodeJSInstallation/6.9.4LTS/bin/grunt -> /home/jenkins/jenkins_home/tools/jenkins.plugins.nodejs.tools.NodeJSInstallation/6.9.4LTS/lib/node_modules/grunt-cli/bin/grunt
/home/jenkins/jenkins_home/tools/jenkins.plugins.nodejs.tools.NodeJSInstallation/6.9.4LTS/bin/gulp -> /home/jenkins/jenkins_home/tools/jenkins.plugins.nodejs.tools.NodeJSInstallation/6.9.4LTS/lib/node_modules/gulp/bin/gulp.js
/home/jenkins/jenkins_home/tools/jenkins.plugins.nodejs.tools.NodeJSInstallation/6.9.4LTS/lib
├── bower@1.7.9 
├── grunt-cli@0.1.13 
└── gulp@3.9.1 

$ bash -c "[ -d \$HOME/.pyenv ]"
Installing pyenv...
$ bash -c "git clone https://github.com/yyuu/pyenv.git \$HOME/.pyenv && cd \$HOME/.pyenv && git checkout master"
bash: git: command not found
FATAL: (CommandError) failed: "git clone https://github.com/yyuu/pyenv.git \\$HOME/.pyenv && cd \\$HOME/.pyenv && git checkout master"
org.jruby.exceptions.RaiseException: (CommandError) failed: "git clone https://github.com/yyuu/pyenv.git \\$HOME/.pyenv && cd \\$HOME/.pyenv && git checkout master"
	at RUBY.run(/home/jenkins/jenkins_home/plugins/pyenv/WEB-INF/classes/lib/pyenv/invoke.rb:18)
	at RUBY.install!(/home/jenkins/jenkins_home/plugins/pyenv/WEB-INF/classes/lib/pyenv.rb:47)
	at RUBY.setup!(/home/jenkins/jenkins_home/plugins/pyenv/WEB-INF/classes/lib/pyenv.rb:20)
	at RUBY.setup(/home/jenkins/jenkins_home/plugins/pyenv/WEB-INF/classes/models/pyenv_wrapper.rb:57)
	at RUBY.setUp(/home/jenkins/jenkins_home/plugins/pyenv/WEB-INF/classes/vendor/gems/gems/jenkins-plugin-runtime-0.2.3/lib/jenkins/model/environment_proxy.rb:8)
Finished: FAILURE
```