### PR TITLE
Quote the TARGETDIR to allow for it containing spaces

### DIFF
--- a/src/main/java/jenkins/plugins/nodejs/tools/NodeJSInstaller.java
+++ b/src/main/java/jenkins/plugins/nodejs/tools/NodeJSInstaller.java
@@ -270,7 +270,7 @@ public class NodeJSInstaller extends DownloadFromUrlInstaller {
             msi.copyFrom(archive);
             try {
                 Launcher launch = temp.createLauncher(listener);
-                ProcStarter starter = launch.launch().cmds(new File("cmd"), "/c", "for %A in (.) do msiexec TARGETDIR=%~sA /a "+ temp.getName() + "\\nodejs.msi /qn /L* " + temp.getName() + "\\log.txt");
+                ProcStarter starter = launch.launch().cmds(new File("cmd"), "/c", "for %A in (.) do msiexec TARGETDIR=\"%~sA\" /a "+ temp.getName() + "\\nodejs.msi /qn /L* " + temp.getName() + "\\log.txt");
                 starter=starter.pwd(expected);
 
                 int exitCode=starter.join();


### PR DESCRIPTION
This fixes an issue we found with the plugin - if the TARGETDIR ended up containing spaces (e.g. c:\ Program Files\...), it would error running msiexec and the job would fail. Put quotes around the path to resolve this issue.