### PR TITLE
Update Jenkins core requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <properties>
         <powermock.version>1.7.0</powermock.version>
-        <jenkins.version>1.651.3</jenkins.version>
+        <jenkins.version>2.71</jenkins.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Because of the removed patch in aecf8fe, Jenkins core requirement needs to be update to 2.71 at least