### PR TITLE
Handle Sun OS platforms (such as solaris)

### DIFF
--- a/src/main/java/jenkins/plugins/nodejs/tools/Platform.java
+++ b/src/main/java/jenkins/plugins/nodejs/tools/Platform.java
@@ -11,7 +11,7 @@ import hudson.model.Node;
  * Supported platform.
  */
 public enum Platform {
-    LINUX("node", "npm", "bin"), WINDOWS("node.exe", "npm.cmd", ""), OSX("node", "npm", "bin");
+    LINUX("node", "npm", "bin"), WINDOWS("node.exe", "npm.cmd", ""), OSX("node", "npm", "bin"), SUN_OS("node", "npm", "bin");
 
     /**
      * Choose the file name suitable for the downloaded Node bundle.
@@ -71,6 +71,9 @@ public enum Platform {
         }
         if (arch.contains("mac")) {
             return OSX;
+        }
+        if (arch.contains("sunos")) {
+            return SUN_OS;
         }
         throw new DetectionFailedException("Unknown OS name: " + arch);
     }


### PR DESCRIPTION
Since node.js has a sun solaris install could it be possible to handle this sort of Platform in the jenkins nodejs-plugin ?