### PR TITLE
Java11 readiness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.23</version>
+        <version>3.40</version>
     </parent>
 
     <artifactId>nodejs</artifactId>
@@ -42,7 +42,6 @@
     </licenses>
 
     <properties>
-        <powermock.version>2.0.0</powermock.version>
         <jenkins.version>2.60.3</jenkins.version>
         <java.level>8</java.level>
     </properties>
@@ -61,15 +60,20 @@
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.9.7</version> <!-- need to force this https://github.com/mockito/mockito/issues/1606#issuecomment-473371126 -->
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <repositories>
@@ -138,13 +142,4 @@
             </build>
         </profile>
     </profiles>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.objenesis</groupId>
-                <artifactId>objenesis</artifactId>
-                <version>3.0.1</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/src/main/java/jenkins/plugins/nodejs/tools/NodeJSInstallation.java
+++ b/src/main/java/jenkins/plugins/nodejs/tools/NodeJSInstallation.java
@@ -43,6 +43,7 @@ import hudson.model.Computer;
 import hudson.model.EnvironmentSpecific;
 import hudson.model.Node;
 import hudson.model.TaskListener;
+import hudson.remoting.VirtualChannel;
 import hudson.slaves.NodeSpecific;
 import hudson.tools.ToolDescriptor;
 import hudson.tools.ToolInstallation;
@@ -120,7 +121,11 @@ public class NodeJSInstallation extends ToolInstallation implements EnvironmentS
     public String getExecutable(final Launcher launcher) throws InterruptedException, IOException {
         // DO NOT REMOVE this callable otherwise paths constructed by File
         // and similar API will be based on the master node O.S.
-        return launcher.getChannel().call(new DetectPlatformCallable());
+        final VirtualChannel channel = launcher.getChannel();
+        if (channel == null) {
+            throw new IOException("Unable to get a channel for the launcher");
+        }
+        return channel.call(new DetectPlatformCallable());
     }
 
     /**


### PR DESCRIPTION
Updates to be able to build correctly on Java 11.

Manually successfully tested ` mvn -V clean verify -Djenkins.version=2.164` both on JDK8 and JDK11.

@nfalco79 as the current maintainer

cc @jenkinsci/java11-support 