### PR TITLE
JENKINS-57844 Fix the backward compatibility.

### DIFF
--- a/src/main/java/jenkins/plugins/nodejs/NodeJSBuildWrapper.java
+++ b/src/main/java/jenkins/plugins/nodejs/NodeJSBuildWrapper.java
@@ -177,6 +177,21 @@ public class NodeJSBuildWrapper extends SimpleBuildWrapper {
         }
     }
 
+    /**
+     * Migrate old data, set cacheLocationStrategy
+     *
+     * @see
+     *      <a href="https://wiki.jenkins-ci.org/display/JENKINS/Hint+on+retaining+backward+compatibility">
+     *          Jenkins wiki entry on the subject</a>
+     *
+     * @return
+     *      must be always 'this'
+     */
+    protected Object readResolve() {
+        this.setCacheLocationStrategy(this.cacheLocationStrategy);
+        return this;
+    }
+
     @Symbol("nodejs")
     @Extension
     public static final class DescriptorImpl extends BuildWrapperDescriptor {


### PR DESCRIPTION
Method readResolve() is called by XStream after deserialization to set cacheLocationStrategy..

https://wiki.jenkins-ci.org/display/JENKINS/Hint+on+retaining+backward+compatibility