### PR TITLE
docs: Add missing import to the script example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Either automatically upon [Jenkins post-initialization](https://wiki.jenkins.io/
 ```groovy
 #!/usr/bin/env groovy
 import hudson.tools.InstallSourceProperty
+import jenkins.model.Jenkins
 import jenkins.plugins.nodejs.tools.NodeJSInstallation
 import jenkins.plugins.nodejs.tools.NodeJSInstaller
 import static jenkins.plugins.nodejs.tools.NodeJSInstaller.DEFAULT_NPM_PACKAGES_REFRESH_HOURS


### PR DESCRIPTION
The previous version would work in the script console (where I've tested it), because it adds some automatic imports.
I've just noticed it doesn't work in the init script.