### PR TITLE
Removing Mockito from NpmrcFileSupplyTest to be compatible with Spring Security

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.2</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,12 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.2</version>
+        <version>4.7</version>
+        <relativePath />
     </parent>
 
     <artifactId>nodejs</artifactId>
-    <version>1.3.8-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <name>NodeJS Plugin</name>
     <description>Executes NodeJS script as a build step.</description>
     <url>https://github.com/jenkinsci/nodejs-plugin</url>
@@ -42,6 +43,9 @@
     </licenses>
 
     <properties>
+        <revision>1.3.8</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <gitHubRepo>jenkinsci/nodejs-plugin</gitHubRepo>
         <java.level>8</java.level>
         <config-file-provider-plugin.version>3.6.3</config-file-provider-plugin.version>
         <byte-buddy.version>1.9.10</byte-buddy.version>
@@ -142,10 +146,10 @@
     </repositories>
 
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/nodejs-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/nodejs-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/nodejs-plugin</url>
-        <tag>HEAD</tag>
+        <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
+        <tag>${scmTag}</tag>
     </scm>
 
     <pluginRepositories>

--- a/src/test/java/jenkins/plugins/nodejs/NpmrcFileSupplyTest.java
+++ b/src/test/java/jenkins/plugins/nodejs/NpmrcFileSupplyTest.java
@@ -25,10 +25,8 @@ package jenkins.plugins.nodejs;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.doReturn;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -39,51 +37,22 @@ import org.jenkinsci.lib.configprovider.model.ConfigFileManager;
 import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.powermock.api.mockito.PowerMockito;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 
-import hudson.EnvVars;
 import hudson.FilePath;
-import hudson.model.Environment;
-import hudson.model.EnvironmentList;
 import hudson.model.FreeStyleBuild;
-import hudson.model.FreeStyleProject;
 import jenkins.plugins.nodejs.configfiles.NPMConfig;
 import jenkins.plugins.nodejs.configfiles.NPMRegistry;
 import jenkins.plugins.nodejs.configfiles.Npmrc;
 
 public class NpmrcFileSupplyTest {
 
-    /* package */ static class MockBuild extends FreeStyleBuild {
-        public MockBuild(FreeStyleProject project, File workspace) throws IOException {
-            super(mock(project));
-            setWorkspace(new FilePath(workspace));
-        }
-
-        private static FreeStyleProject mock(FreeStyleProject project) {
-            FreeStyleProject spy = PowerMockito.spy(project);
-            doReturn(new EnvVars()).when(spy).getCharacteristicEnvVars();
-            return spy;
-        }
-
-        @Override
-        public EnvironmentList getEnvironments() {
-            if (buildEnvironments == null) {
-                buildEnvironments = new ArrayList<Environment>();
-            }
-            return new EnvironmentList(buildEnvironments);
-        }
-    }
-
     @Rule
     public JenkinsRule j = new JenkinsRule();
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
 
     @Test
     public void test_supply_npmrc_with_registry() throws Exception {
@@ -93,7 +62,7 @@ public class NpmrcFileSupplyTest {
 
         Config config = createSetting("mytest", "email=guest@example.com", Arrays.asList(privateRegistry, officalRegistry));
 
-        FreeStyleBuild build = new MockBuild(j.createFreeStyleProject(), folder.newFolder());
+        FreeStyleBuild build = j.buildAndAssertSuccess(j.createFreeStyleProject());
 
         FilePath npmrcFile = ConfigFileManager.provisionConfigFile(new ConfigFile(config.id, null, true), null, build, build.getWorkspace(), j.createTaskListener(), new ArrayList<String>(1));
         assertTrue(npmrcFile.exists());


### PR DESCRIPTION
`plugin-compat-tester` compatibility with https://github.com/jenkinsci/jenkins/pull/4848. Without this, there is a `StackOverflowError` in `Queue$Task.getDefaultAuthentication2` vs. `Queue$Task.getDefaultAuthentication` because Mockito is doing something weird with `hudson.model.FreeStyleProject$MockitoMock$1321742843`. Anyway this test was already using `JenkinsRule` and paying that overhead, so there was no reason to introduce a mock framework; just making things more brittle.