### PR TITLE
Add compatibility with Jenkins 2.264+

### DIFF
--- a/src/main/resources/jenkins/plugins/nodejs/configfiles/NPMConfig/show-config.jelly
+++ b/src/main/resources/jenkins/plugins/nodejs/configfiles/NPMConfig/show-config.jelly
@@ -23,6 +23,21 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+   <d:taglib uri="local">
+       <!-- custom tag to DRY the representation of the information for the registries -->
+       <d:tag name="registryInfo">
+           <f:entry title="${%registry.url}" description="${empty(registry.scopes)? '%registry.global' : '%registry.scoped'}">
+               <f:textbox readonly="readonly" name="registry.url" value="${registry.url}" />
+           </f:entry>
+           <j:if test="${!empty(registry.scopes)}">
+               <f:entry title="${%registry.scopes}">
+                   <f:textbox readonly="readonly" name="registry.scopes" value="${registry.scopes}" />
+               </f:entry>
+           </j:if>
+       </d:tag>
+   </d:taglib>
+
     <!-- needed for repeatable properties -->
     <j:set var="instance" value="${config}" />
 
@@ -40,19 +55,27 @@ THE SOFTWARE.
         <f:textbox readonly="readonly" name="config.comment" value="${config.comment}" />
     </f:entry>
 
-    <f:entry title="${%registry.title}">
-        <table style="width:100%">
-            <j:forEach var="registry" items="${config.registries}">
-                <f:entry title="${%registry.url}" description="${empty(registry.scopes)? '%registry.global' : '%registry.scoped'}">
-                    <f:textbox readonly="readonly" name="registry.url" value="${registry.url}" />
-                </f:entry>
-                <j:if test="${!empty(registry.scopes)}">
-                    <f:entry title="${%registry.scopes}">
-                        <f:textbox readonly="readonly" name="registry.scopes" value="${registry.scopes}" />
-                    </f:entry>
-                </j:if>
-            </j:forEach>
-        </table>
+    <f:entry title="${%registry.title}" xmlns:local="local">
+        <!-- fix for https://issues.jenkins.io/browse/JENKINS-62911 -->
+        <j:choose>
+            <j:when test="${divBasedFormLayout}">
+                <!-- puting the items within a list for better visualization on a div-based layout -->
+                <ul>
+                    <j:forEach var="registry" items="${config.registries}">
+                        <li>
+                            <local:registryInfo registry="${registry}" />
+                        </li>
+                    </j:forEach>
+                </ul>
+            </j:when>
+            <j:otherwise>
+                <table style="width:100%;">
+                    <j:forEach var="registry" items="${config.registries}">
+                        <local:registryInfo registry="${registry}" />
+                    </j:forEach>
+                </table>
+            </j:otherwise>
+        </j:choose>
     </f:entry>
 
     <f:entry title="${%content.title}">


### PR DESCRIPTION
Fix for [JENKINS-62911](https://issues.jenkins.io/browse/JENKINS-62911)

This PR updates the markup on the readonly .npmrc configuration (managed file) screen to be tables-to-divs compatible. The screen can be shown at `/configfiles/show?id=<script ID>`

The registries are shown within a list on div-based layouts in order to be visually nested. See the screenshots:

<details>
<summary>Pre Jenkins 2.264</summary>

<img width="1342" alt="Captura de pantalla 2020-12-17 a las 14 01 26" src="https://user-images.githubusercontent.com/5738588/102492196-a2199600-4071-11eb-9a0b-12f9a2ef96f7.png">
</details>

<details>
<summary>Jenkins 2.264+</summary>

<img width="1378" alt="Captura de pantalla 2020-12-17 a las 14 02 38" src="https://user-images.githubusercontent.com/5738588/102492221-a9d93a80-4071-11eb-820b-232446982655.png">
</details>