### PR TITLE
truncate config file before writing to it

### DIFF
--- a/src/main/java/jenkins/plugins/nodejs/configfiles/Npmrc.java
+++ b/src/main/java/jenkins/plugins/nodejs/configfiles/Npmrc.java
@@ -23,21 +23,21 @@
  */
 package jenkins.plugins.nodejs.configfiles;
 
+import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.StringReader;
-import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
-import org.apache.commons.io.output.FileWriterWithEncoding;
 
 /**
  * Npm config file parser.
@@ -46,8 +46,6 @@ import org.apache.commons.io.output.FileWriterWithEncoding;
  * @since 1.0
  */
 public class Npmrc {
-    private static final String UTF_8 = "UTF-8";
-
     private Map<Object, String> properties = new LinkedHashMap<>();
 
     /**
@@ -67,7 +65,7 @@ public class Npmrc {
         }
 
         Path path = Paths.get(file.getAbsolutePath());
-        String content = new String(Files.readAllBytes(path), UTF_8);
+        String content = new String(Files.readAllBytes(path), StandardCharsets.UTF_8.name());
 
         Npmrc config = new Npmrc();
         config.from(content);
@@ -142,11 +140,9 @@ public class Npmrc {
      * @throws IOException in case of I/O write error
      */
     public void save(File file) throws IOException {
-        // FileWriterWithEncoding does not truncate file if it already exists
-        new FileOutputStream(file).close();
-        try (Writer writer = new FileWriterWithEncoding(file, UTF_8)) {
-            IOUtils.write(toString(), writer);
-        }
+        BufferedWriter writer = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING);
+        writer.write(toString());
+        writer.close();
     }
 
     /**

--- a/src/main/java/jenkins/plugins/nodejs/configfiles/Npmrc.java
+++ b/src/main/java/jenkins/plugins/nodejs/configfiles/Npmrc.java
@@ -24,6 +24,7 @@
 package jenkins.plugins.nodejs.configfiles;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.Writer;
@@ -141,6 +142,8 @@ public class Npmrc {
      * @throws IOException in case of I/O write error
      */
     public void save(File file) throws IOException {
+        // FileWriterWithEncoding does not truncate file if it already exists
+        new FileOutputStream(file).close();
         try (Writer writer = new FileWriterWithEncoding(file, UTF_8)) {
             IOUtils.write(toString(), writer);
         }

--- a/src/main/java/jenkins/plugins/nodejs/configfiles/Npmrc.java
+++ b/src/main/java/jenkins/plugins/nodejs/configfiles/Npmrc.java
@@ -23,19 +23,17 @@
  */
 package jenkins.plugins.nodejs.configfiles;
 
-import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
 
@@ -46,6 +44,8 @@ import org.apache.commons.io.LineIterator;
  * @since 1.0
  */
 public class Npmrc {
+    private static final String UTF_8 = "UTF-8";
+
     private Map<Object, String> properties = new LinkedHashMap<>();
 
     /**
@@ -65,7 +65,7 @@ public class Npmrc {
         }
 
         Path path = Paths.get(file.getAbsolutePath());
-        String content = new String(Files.readAllBytes(path), StandardCharsets.UTF_8.name());
+        String content = new String(Files.readAllBytes(path), UTF_8);
 
         Npmrc config = new Npmrc();
         config.from(content);
@@ -140,9 +140,7 @@ public class Npmrc {
      * @throws IOException in case of I/O write error
      */
     public void save(File file) throws IOException {
-        BufferedWriter writer = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING);
-        writer.write(toString());
-        writer.close();
+        FileUtils.writeStringToFile(file, toString(), UTF_8);
     }
 
     /**


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
The test NpmrcTest.testCommandAtLast tests whether a comment saved to the npm config file is the last line of the config file.  However, if you inspect the actual file, you can see that the old config file data still exists.
For Jenkins versions with commons-io 2.11.0, this test will fail correctly.

The reason for this failure is because commons-io uses CREATE as opposed to TRUNCATE_EXISTING.



- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
