### PR TITLE
[JENKINS-67536] Enable a download cache to prevent packages from being downloaded multiple times

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.17</version>
+        <version>4.33</version>
     </parent>
 
     <artifactId>nodejs</artifactId>
@@ -46,27 +46,29 @@
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/nodejs-plugin</gitHubRepo>
         <java.level>8</java.level>
+        <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#changing-the-minimum-required-version -->
+        <jenkins.version>2.289.1</jenkins.version>
 
         <checkstyle.version>8.41</checkstyle.version>
         <config-file-provider-plugin.version>3.6.3</config-file-provider-plugin.version>
         <assertj.version>3.15.0</assertj.version>
-        <jenkins.version>2.222.4</jenkins.version>
+        <powermock.version>2.0.9</powermock.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.222.x</artifactId>
-                <version>26</version>
+                <artifactId>bom-2.289.x</artifactId>
+                <version>1090.v0a_33df40457a_</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
-            <!-- need to force this https://github.com/mockito/mockito/issues/1606#issuecomment-473371126 -->
             <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
-                <version>2.2</version>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <!-- with version 4.x test fails -->
+                <version>3.12.4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -86,6 +88,12 @@
             <artifactId>plain-credentials</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>
@@ -94,11 +102,19 @@
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/jenkins/plugins/nodejs/tools/ToolsUtils.java
+++ b/src/main/java/jenkins/plugins/nodejs/tools/ToolsUtils.java
@@ -78,14 +78,19 @@ import net.sf.json.JSONObject;
     }
 
     public static List<? extends Installable> getInstallable() throws IOException {
-        JSONObject d = Downloadable.get("hudson.plugins.nodejs.tools.NodeJSInstaller").getData();
-        if (d == null) {
-            return Collections.emptyList();
+        List<Installable> installables = Collections.emptyList();
+
+        Downloadable downloadable = Downloadable.get("hudson.plugins.nodejs.tools.NodeJSInstaller");
+        if (downloadable != null) {
+            JSONObject d = downloadable.getData();
+            if (d != null) {
+                installables = Arrays.asList(((InstallableList) JSONObject.toBean(d, InstallableList.class)).list).stream() //
+                        .filter(i -> !InstallerPathResolver.Factory.isVersionBlacklisted(i.id)) //
+                        .sorted(new InstallableComparator()) //
+                        .collect(Collectors.toList());
+            }
         }
-        return Arrays.asList(((InstallableList) JSONObject.toBean(d, InstallableList.class)).list).stream() //
-                .filter(i -> !InstallerPathResolver.Factory.isVersionBlacklisted(i.id)) //
-                .sorted(new InstallableComparator()) //
-                .collect(Collectors.toList());
+        return installables;
     }
 
 }

--- a/src/main/resources/jenkins/plugins/nodejs/Messages.properties
+++ b/src/main/resources/jenkins/plugins/nodejs/Messages.properties
@@ -23,6 +23,8 @@
 
 NodeJSInstaller.DescriptorImpl.displayName=Install from nodejs.org
 NodeJSInstaller.FailedToInstallNodeJS=Failed to install NodeJS. Exit code={0}
+NodeJSInstaller.installFromCache=Installing NodeJS from {0} to {1} on {2}
+NodeJSInstaller.failedToUnpack=Failed to unpack {0} ({1} bytes read)
 NodeJSInstallation.displayName=NodeJS
 NodeJSBuildWrapper.displayName=Provide Node & npm bin/ folder to PATH
 NodeJSCommandInterpreter.displayName=Execute NodeJS script

--- a/src/test/java/jenkins/plugins/nodejs/tools/ToolsUtilsTest.java
+++ b/src/test/java/jenkins/plugins/nodejs/tools/ToolsUtilsTest.java
@@ -33,7 +33,6 @@ import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import hudson.model.Node;
 
@@ -44,12 +43,6 @@ public class ToolsUtilsTest {
     @Before
     public void setup() {
         CPU[] cpuValues = CPU.values();
-        CPU mock = PowerMockito.mock(CPU.class);
-        for (CPU c : cpuValues) {
-            Whitebox.setInternalState(mock, "name", c.name());
-            Whitebox.setInternalState(mock, "ordinal", c.ordinal());
-        }
-
         PowerMockito.mockStatic(CPU.class);
         PowerMockito.when(CPU.values()).thenReturn(cpuValues);
     }


### PR DESCRIPTION
Add a download cache that store all nodejs packages per architecture/platform

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue