### PR TITLE
Refresh plugin for August 2023

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.66</version>
+        <version>4.72</version>
         <relativePath />
     </parent>
 
@@ -60,7 +60,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.387.x</artifactId>
-                <version>2329.v078520e55c19</version>
+                <version>2378.v3e03930028f2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -75,7 +75,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>config-file-provider</artifactId>
-            <version>953.v0432a_802e4d2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -141,7 +140,7 @@
         <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
         <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>
-        <tag>nodejs-1.6.1</tag>
+        <tag>${scmTag}</tag>
     </scm>
 
     <pluginRepositories>


### PR DESCRIPTION
Updates the plugin parent POM and BOM, which allowed us to remove a version of a plugin dependency that is now managed by the BOM. Also the tag was set incorrectly for incremental builds.