### PR TITLE
Add `cloudbees-folder` to test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>cloudbees-folder</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
While running Plugin Compatibility Tester (PCT) against this plugin I noticed the following failure:

```
java.lang.ClassNotFoundException: com.cloudbees.hudson.plugins.folder.AbstractFolder
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
Caused: java.lang.NoClassDefFoundError: com/cloudbees/hudson/plugins/folder/AbstractFolder
	at org.jenkinsci.plugins.configfiles.ConfigFiles.getByIdOrNull(ConfigFiles.java:139)
	at org.jenkinsci.plugins.configfiles.ConfigFiles.getByIdOrNull(ConfigFiles.java:169)
	at org.jenkinsci.lib.configprovider.model.ConfigFileManager.provisionConfigFile(ConfigFileManager.java:67)
	at jenkins.plugins.nodejs.NodeJSCommandInterpreter.perform(NodeJSCommandInterpreter.java:172)
	at hudson.tasks.CommandInterpreter.perform(CommandInterpreter.java:92)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:818)
	at hudson.model.Build$BuildExecution.build(Build.java:199)
	at hudson.model.Build$BuildExecution.doRun(Build.java:164)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:526)
	at hudson.model.Run.execute(Run.java:1895)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:44)
	at hudson.model.ResourceController.execute(ResourceController.java:101)
	at hudson.model.Executor.run(Executor.java:442)
```

This PR chases away the failure by adding `cloudbees-folder` (of a BOM managed version) to test scope.

### Testing done

Successfully ran PCT with this change on Java 21. Before this change, I got:

```
[ERROR] Errors: 
[ERROR]   JCasCTest>RoundTripAbstractTest.lambda$roundTripTest$0:104->assertConfiguredAsExpected:64->checkConfigFile:69 » NoClassDefFound com/cloudbees/hudson/plugins/folder/AbstractFolder
[ERROR]   NpmrcFileSupplyTest.test_supply_npmrc_with_registry:67 » NoClassDefFound com/cloudbees/hudson/plugins/folder/AbstractFolder
```